### PR TITLE
turning off cache sync to limit HF communications

### DIFF
--- a/labs/FineTuning/HuggingFaceExample/01_finetuning/Finetune-TinyLlama-1.1B.ipynb
+++ b/labs/FineTuning/HuggingFaceExample/01_finetuning/Finetune-TinyLlama-1.1B.ipynb
@@ -49,13 +49,13 @@
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m25.0.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m25.1.1\u001b[0m\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
+     "ename": "",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31mRunning cells with 'Python 3.11.12' requires the ipykernel package.\n",
+      "\u001b[1;31m<a href='command:jupyter.createPythonEnvAndSelectController'>Create a Python Environment</a> with the required packages.\n",
+      "\u001b[1;31mOr install 'ipykernel' using the command: '/opt/homebrew/bin/python3.11 -m pip install ipykernel -U --user --force-reinstall'"
      ]
     }
    ],
@@ -216,6 +216,7 @@
     "hyperparameters = {\n",
     "    \"model_id\": \"TinyLlama/TinyLlama-1.1B-Chat-v1.0\",\n",
     "    \"tokenizer_id\": \"TinyLlama/TinyLlama-1.1B-Chat-v1.0\",\n",
+    "    \"skip_cache_push\": True,\n",
     "    \"output_dir\": \"/opt/ml/model\",\n",
     "    \"tensor_parallel_size\": 2,\n",
     "    \"bf16\": True,\n",


### PR DESCRIPTION
Hopefully the final commit for a while.  This just turns off the HF cache sync (which should be ineffective for most tokens anyway), but did cause a problem once because of network issues.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
